### PR TITLE
Xml to json stream/patch/1.0.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
 
         if(!validator(clean)) {
             const err = new Error('Invalid XML. XML is missing closing or opening tag');
-            return cb(e);
+            return cb(err);
         }
 
         let json;

--- a/lib/xmlToJson.js
+++ b/lib/xmlToJson.js
@@ -37,12 +37,6 @@ function traverse(xml,attributeMode) {
             const err = new Error('Invalid XML');
             throw err;
         }
-
-        // if(selfClosing === false && closingTagIndex > input.indexOf(tag,tagLength)) {
-        //     const err = new Error('Invalid XML. Illegal start of XML tag');
-        //     throw err;
-        // }
-        
         
         let substring; //substring will be either all child tags or if self closing tag just a blank string. i.e: <employee><name>Alex</name></employee> : <name>Alex</name> will be the substring of the <employee> parent tag
         if(selfClosing) {
@@ -224,7 +218,7 @@ function validate(currentTag) {
 
 
 function findClosingIndex(searchString,tag,start) {
-    
+
     const openinTag   = tag.replace('</', '<').replace('>', '');
     let closingIndex  = searchString.indexOf(tag,start);
     let openingIndex  = searchString.indexOf(openinTag,start);

--- a/lib/xmlToJson.js
+++ b/lib/xmlToJson.js
@@ -31,7 +31,7 @@ function traverse(xml,attributeMode) {
             const err = new Error('Invalid XML tag');
             throw err;
         }
-        // const closingTagIndex = input.indexOf(finishTag,tagLength);
+        //const closingTagIndex = input.indexOf(finishTag,tagLength);
         const closingTagIndex = findClosingIndex(input,finishTag,tagLength);
         if(selfClosing === false && closingTagIndex < 0) {
             const err = new Error('Invalid XML');
@@ -224,17 +224,23 @@ function validate(currentTag) {
 
 
 function findClosingIndex(searchString,tag,start) {
-    let offset = start;
-    let index  = searchString.indexOf(tag,start);
+    
+    const openinTag   = tag.replace('</', '<').replace('>', '');
+    let closingIndex  = searchString.indexOf(tag,start);
+    let openingIndex  = searchString.indexOf(openinTag,start);
 
-    while(index > 0) {
-        const tempIndex = searchString.indexOf(tag,index+1);
+    if(closingIndex < openingIndex) {
+        return closingIndex;
+    }
+
+    while(closingIndex > 0) {
+        const tempIndex = searchString.indexOf(tag,closingIndex+1);
         if(tempIndex > 0) {
-            index = tempIndex;
+            closingIndex = tempIndex;
         } else {
             break;
         }
     }
 
-    return index;
+    return closingIndex;
 }

--- a/lib/xmlToJson.js
+++ b/lib/xmlToJson.js
@@ -31,16 +31,17 @@ function traverse(xml,attributeMode) {
             const err = new Error('Invalid XML tag');
             throw err;
         }
-        const closingTagIndex = input.indexOf(finishTag,tagLength);
+        // const closingTagIndex = input.indexOf(finishTag,tagLength);
+        const closingTagIndex = findClosingIndex(input,finishTag,tagLength);
         if(selfClosing === false && closingTagIndex < 0) {
             const err = new Error('Invalid XML');
             throw err;
         }
 
-        if(selfClosing === false && closingTagIndex > input.indexOf(tag,tagLength)) {
-            const err = new Error('Invalid XML. Illegal start of XML tag');
-            throw err;
-        }
+        // if(selfClosing === false && closingTagIndex > input.indexOf(tag,tagLength)) {
+        //     const err = new Error('Invalid XML. Illegal start of XML tag');
+        //     throw err;
+        // }
         
         
         let substring; //substring will be either all child tags or if self closing tag just a blank string. i.e: <employee><name>Alex</name></employee> : <name>Alex</name> will be the substring of the <employee> parent tag
@@ -49,7 +50,7 @@ function traverse(xml,attributeMode) {
             skip = currentTag.length + skip;
 
         } else {
-            substring = input.substring(input.indexOf('>', skip)+1, input.indexOf(finishTag,tagLength));
+            substring = input.substring(input.indexOf('>', skip)+1, closingTagIndex);
             skip = tagLength + substring.length + finishTag.length;
         }
         
@@ -219,4 +220,21 @@ function validate(currentTag) {
     }
 
     return false;
+}
+
+
+function findClosingIndex(searchString,tag,start) {
+    let offset = start;
+    let index  = searchString.indexOf(tag,start);
+
+    while(index > 0) {
+        const tempIndex = searchString.indexOf(tag,index+1);
+        if(tempIndex > 0) {
+            index = tempIndex;
+        } else {
+            break;
+        }
+    }
+
+    return index;
 }

--- a/spec/mockXML/index.js
+++ b/spec/mockXML/index.js
@@ -51,6 +51,15 @@ const TEST8 =  `
 
 const TEST9 = `<employee id="98765">Alex</employee>`
 
+//Invalid XML
+const TEST10 = `<employee id="98765">Alex</employee`
+const TEST11 = `<employee id="98765">Alex<employee>`
+const TEST12 = `<employee id="98765"><employee id="12345">Jon<employee></employee>`
+
+//nested repetition
+const TEST13 = `<employee id="98765" name="alex"><employee id="123" name="jon"></employee></employee>`;
+const TEST14 = `<employee id="98765" name="alex"><employee>Alex</employee></employee>`
+
 
 
 module.exports.MOCK_DATA = {
@@ -62,5 +71,10 @@ module.exports.MOCK_DATA = {
     TEST6: TEST6,
     TEST7: TEST7,
     TEST8: TEST8,
-    TEST9: TEST9
+    TEST9: TEST9,
+    I_TEST10: TEST10,
+    I_TEST11: TEST11,
+    I_TEST12: TEST12,
+    TEST13: TEST13,
+    TEST14: TEST14
 };

--- a/spec/traverse-spec.js
+++ b/spec/traverse-spec.js
@@ -191,11 +191,6 @@ describe('TRAVERSE: With Attributes', ()=>{
 
 
 
-
-
-
-
-
 describe('TRAVERSE: Without Attributes', ()=>{
     const attributeMode = false;
 
@@ -296,6 +291,76 @@ describe('TRAVERSE: Without Attributes', ()=>{
         }
 
         expect(JSON.stringify(json)).toBe(JSON.stringify(result));
-    })
+    });
 });
+
+
+describe('ERRORS: Invalid XML', ()=>{
+    const attributeMode = true;
+
+    it('should throw an error with invalid xml 1', ()=>{
+        const cleanXML = clean(mockData.I_TEST10);
+        
+        expect(traverse.bind(null,cleanXML,attributeMode)).toThrowError(Error, "Invalid XML")
+        
+    });
+
+    it('should throw an error with invalid xml 2', ()=>{
+        const cleanXML = clean(mockData.I_TEST11);
+        
+        expect(traverse.bind(null,cleanXML,attributeMode)).toThrowError(Error, "Invalid XML")
+        
+    });
+
+    it('should throw an error with invalid xml 3', ()=>{
+        const cleanXML = clean(mockData.I_TEST12);
+        
+        expect(traverse.bind(null,cleanXML,attributeMode)).toThrowError(Error, "Invalid XML")
+        
+    });
+});
+
+
+
+describe('NESTING: Repetions', ()=>{
+    const attributeMode = true;
+
+    it('should correctly parse nested repeated xml tags', ()=>{
+        const cleanXML = clean(mockData.TEST13);
+        const json     = traverse(cleanXML,attributeMode);
+
+        const result = {
+            employee: {
+                id: "98765",
+                name: "alex",
+                employee: {
+                    id: "123",
+                    name: "jon"
+                }
+            }
+        }
+
+        expect(JSON.stringify(json)).toBe(JSON.stringify(result));
+        
+        
+    });
+
+    it('should throw an error with invalid xml 2', ()=>{
+        const cleanXML = clean(mockData.TEST14);
+        const json     = traverse(cleanXML,attributeMode);
+
+        const result = {
+            employee: {
+                id: "98765",
+                name: "alex",
+                employee: "Alex"
+            }
+        }
+
+        expect(JSON.stringify(json)).toBe(JSON.stringify(result));
+        
+    });
+
+});
+
 


### PR DESCRIPTION
traverse function was not correctly parsing nested repeated elements such as:
`<employee id="123">
       <employee id="345"></employee>
</employee>`

error was a result of not correctly identifying the closing tag. this was fixed by introducing a `findClosingTagIndex` function to always return the true closing index even in situation like above.