### PR TITLE
fix incorrect parsing of child elements with the same tag as the parent

### DIFF
--- a/lib/cleanXML.js
+++ b/lib/cleanXML.js
@@ -2,7 +2,7 @@
 module.exports = function cleanXML(xml) {
     return xml.replace(/>\s*</g, '><') //remove white spaces between elements
                 .replace(/<\?xml.*\?>/g, '') //remove the root element
-                .replace(/<!--.*-->/g,'') //remove comments
+                .replace(/<!--[\s\S\n]*?-->/g,'') //remove comments
                 .replace(/>\s*/g, '>') // remove any white spaces at the end of the xml string if any
                 .replace(/\s*</g, '<') // remove any white spaces that are left at the beginning of the xml string
     

--- a/lib/xmlToJson.js
+++ b/lib/xmlToJson.js
@@ -4,7 +4,7 @@ function traverse(xml,attributeMode) {
     const tagFinder = new RegExp('<(.*?)[>|\\s|/]', 'g'); //find the current tag we are working on
 
     const json = {};
-    let tagShouldBeArray = false;
+    let tagShouldBeArray = {};
     
     //recursion base case
     if(xml === '' || (xml.charAt(0) !== '<' && xml.charAt(xml.length-1) !== '>')) {
@@ -54,7 +54,7 @@ function traverse(xml,attributeMode) {
         if(!json[tag]) {
             json[tag] = {};
         } else {
-            tagShouldBeArray = true;
+            tagShouldBeArray[tag] = true;
         }
         
 
@@ -65,10 +65,10 @@ function traverse(xml,attributeMode) {
         }
 
         //if currentTag contains attributes and attributeMode is enabled, attach them to json
-        if(tagShouldBeArray && attributeMode) {
+        if(tagShouldBeArray[tag] && attributeMode) {
             temporary = attributes;
 
-        } else if(!tagShouldBeArray && attributeMode) {
+        } else if(!tagShouldBeArray[tag] && attributeMode) {
             for(let key in attributes) {
                 json[tag][key] = attributes[key];
             }
@@ -82,7 +82,7 @@ function traverse(xml,attributeMode) {
         
         if(typeof next === 'object') {
             //const key = Object.keys(next)[0];
-            if(tagShouldBeArray && !json[tag].length) {
+            if(tagShouldBeArray[tag] && !json[tag].length) {
                 const temp = json[tag];
                 json[tag] = [temp];
                 const nextObj = {}
@@ -91,7 +91,7 @@ function traverse(xml,attributeMode) {
                 }
                 temporary = {...temporary,...nextObj};
                 json[tag].push(temporary);
-            }else if(tagShouldBeArray) {
+            }else if(tagShouldBeArray[tag]) {
                 const nextObj = {};
                 for(let key in next) {
                     nextObj[key] = next[key];
@@ -107,7 +107,7 @@ function traverse(xml,attributeMode) {
 
         } else if(Object.keys(json[tag]).length>0) {
         
-            if((tagShouldBeArray  && !json[tag].length) || typeof json[tag] === 'string') {
+            if((tagShouldBeArray[tag]  && !json[tag].length) || typeof json[tag] === 'string') {
                 const temp = json[tag];
                 json[tag] = [temp];
                 
@@ -129,7 +129,7 @@ function traverse(xml,attributeMode) {
                 }
                 //json[tag].push(next);
 
-            } else if(tagShouldBeArray) {
+            } else if(tagShouldBeArray[tag]) {
                 //json[tag].push(next);
                 if(typeof next !== 'object') {
                     if(Object.keys(temporary).length === 0) {
@@ -159,7 +159,7 @@ function traverse(xml,attributeMode) {
             }
             
         } else {
-            if(tagShouldBeArray && typeof json[tag] !== 'object') {
+            if(tagShouldBeArray[tag] && typeof json[tag] !== 'object') {
                 const temp = json[tag];
                 json[tag] = [];
                 json[tag].push(...temp,next);

--- a/lib/xmlToJson.js
+++ b/lib/xmlToJson.js
@@ -32,7 +32,7 @@ function traverse(xml,attributeMode) {
             throw err;
         }
         //const closingTagIndex = input.indexOf(finishTag,tagLength);
-        const closingTagIndex = findClosingIndex(input,finishTag,tagLength);
+        const closingTagIndex = findClosingIndex(input,tag,tagLength);
         if(selfClosing === false && closingTagIndex < 0) {
             const err = new Error('Invalid XML');
             throw err;
@@ -216,31 +216,30 @@ function validate(currentTag) {
     return false;
 }
 
+function findClosingIndex(searchString, tag, start) {
 
-function findClosingIndex(searchString,tag,start) {
+    let index = start;
+    const closeTag = '</' + tag + '>'
+    let nextClose = searchString.indexOf(closeTag,index);
+    const openPattern = new RegExp('<' + tag + '[>\\s/]', 'g');
+    openPattern.lastIndex = index;
+    let nextOpen = openPattern.exec(searchString);
+    let pendingTags = 1;
 
-    const openinTag   = tag.replace('</', '<').replace('>', '');
-    let closingIndex  = searchString.indexOf(tag,start);
-    let openingIndex  = searchString.indexOf(openinTag,start);
-
-    if(closingIndex < openingIndex) {
-        return closingIndex;
-    }
-
-    const sub  = searchString.substr(openingIndex,closingIndex-openingIndex);
-
-    if(!sub.match(new RegExp(openinTag + "\\W"))) {
-        return closingIndex;
-    }
-
-    while(closingIndex > 0) {
-        const tempIndex = searchString.indexOf(tag,closingIndex+1);
-        if(tempIndex > 0) {
-            closingIndex = tempIndex;
+    while(pendingTags) {
+        if(nextClose < 0) {
+            return nextClose;
+        } else if(!nextOpen || nextClose < nextOpen.index) {
+            pendingTags -= 1;
+            index = nextClose;
+            nextClose = searchString.indexOf(closeTag, index + 1);
         } else {
-            break;
+            pendingTags += 1;
+            index = nextOpen.index;
+            openPattern.lastIndex = index + 1;
+            nextOpen = openPattern.exec(searchString);
         }
     }
 
-    return closingIndex;
+    return index;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xml-to-json-stream",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Simple module to convert XML to JSON with javascript",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The previous fix in findClosingIndex was failing to parse xml in the form

`
<a>
  <a>
    <a></a>
  </a>
  <a>
    <a></a>
  </a>
</a>
`

due to only looking one level deep. This version will properly track the number of open tags that need to be accounted for instead of skipping to the last one available.